### PR TITLE
Slightly more pythonic approach

### DIFF
--- a/chromelogger.py
+++ b/chromelogger.py
@@ -16,140 +16,111 @@
 # @see https://chrome.google.com/webstore/detail/noaneddfkdjfnfdakjjmocngnfkfehhd
 # @see http://chromelogger.com
 import json
-import traceback
+import logging
+import re
+
 import jsonpickle
 
-# use custom name
-jsonpickle.tags.OBJECT = '___class_name'
-set_header = None
 version = '0.2.2'
 
+HEADER_NAME = 'X-ChromeLogger-Data'
+JSON_HEADER = {
+    'version': version,
+    'columns': ['log', 'backtrace', 'type'],
+}
+PYTHON_INTERPOLATION = re.compile(r'''(
+    %  # the percent character
+    (?:\([0-9a-z_]+\))?  # mapping
+    [#0 +-]*  # conversion flags
+    [*0-9]*  # minimum width
+    (?:.[*0-9]*)?  # precision
+    [hlL]?  # length modifier
+    [diouxXeEfFgGcrs%]  # conversion
+    )''', re.X)
 
-class Console(object):
-    HEADER_NAME = 'X-ChromeLogger-Data'
-
-    _instance = None
-
-    def __init__(self):
-        global version
-
-        self.json = {
-            'version': version,
-            'columns': ['log', 'backtrace', 'type'],
-            'rows': []
-        }
-        self.backtrace_level = 2
-        self.backtraces = []
-
-    @staticmethod
-    def instance():
-        if Console._instance is None:
-            Console._instance = Console()
-
-        return Console._instance
-
-    def _is_literal(self, data):
-        return data is None or isinstance(data, (str, int, long, float, bool))
-
-    def _convert(self, data):
-        return json.loads(jsonpickle.encode(data))
-
-    def _log(self, args):
-        type = args[0:1]
-        args = args[1:]
-
-        # since this is data being transmitted as a header setting
-        # log to empty string is just a way to send less data
-        # the extension defaults to doing console.log
-        if type == 'log':
-            type = ''
-
-        logs = []
-        for arg in args:
-            logs.append(self._convert(arg))
-
-        backtrace_info = traceback.extract_stack()[:-self.backtrace_level].pop()
-
-        # path/to/file.py : line_number
-        backtrace = backtrace_info[0] + ' : ' + str(backtrace_info[1])
-
-        # if two logs are on the same line (for example in a loop)
-        # then we should not log the backtrace again
-        if backtrace in self.backtraces:
-            backtrace = None
-
-        # store backtraces in list so we can tell later if it was
-        # already used
-        if backtrace is not None:
-            self.backtraces.append(backtrace)
-
-        self._add_row(logs, backtrace=backtrace, type=type)
-
-    def _add_row(self, logs, backtrace=None, type=''):
-        global set_header
-
-        row = [logs, backtrace, type]
-        self.json['rows'].append(row)
-
-        # if a set_header function is defined then we will
-        # call that with each row added
-        #
-        # this class is a singleton so it will just overwrite
-        # the existing header with more data each time
-        if set_header is not None:
-            set_header(Console.HEADER_NAME, self._encode(self.json))
-
-    def _encode(self, data):
-        json_data = json.dumps(data)
-        utf8_encode_data = json_data.encode('utf-8')
-        return utf8_encode_data.encode('base64').replace('\n', '')
-
-    def _get_header(self):
-        if len(self.json['rows']) == 0:
-            return None
-
-        return (Console.HEADER_NAME, self._encode(self.json))
+_last_backtrace = None
+rows = []
+backtrace_level = 2
 
 
-def reset():
-    Console._instance = None
+def _convert(data):
+    serialized = json.loads(jsonpickle.encode(data))
+    if isinstance(serialized, dict):
+        serialized['___class_name'] = serialized.pop('py/object')
+    return serialized
 
 
-def get_header(flush=True):
-    header = Console.instance()._get_header()
-    if flush:
-        reset()
-
-    return header
-
-
-def log(*args):
-    args = ('log',) + args
-    Console.instance()._log(args)
-
-
-def warn(*args):
-    args = ('warn',) + args
-    Console.instance()._log(args)
+def _reformat_msg(msg, args):
+    unclaimed = args[:]
+    tokens = PYTHON_INTERPOLATION.split(msg)
+    parts = []
+    for token in tokens:
+        if token.startswith('%') and not token.startswith(r'%%'):
+            arg = unclaimed.pop(0)
+            if isinstance(arg, dict):
+                parts.append('%O')
+            else:
+                parts.append('%s')
+        else:
+            parts.append(token)
+    return ''.join(parts)
 
 
-def error(*args):
-    args = ('error',) + args
-    Console.instance()._log(args)
+def _log(typ, msg, args, backtrace):
+    global _last_backtrace
+    if backtrace == _last_backtrace:
+        backtrace = None
+    else:
+        _last_backtrace = backtrace
+    args = [_convert(arg) for arg in args]
+    msg = _reformat_msg(msg, args)
+    row = [[msg] + args, backtrace, typ]
+    rows.append(row)
 
 
-# this is middleware for django.  ater this module is installed just add
-# "chromelogger.DjangoMiddleware" to your MIDDLEWARE_CLASSES in settings.py
-#
-# after that you can just
-# import chromelogger
-# chromelogger.log('Hello world!')
-#
-# from anywhere in your Django application
+def _encode(data):
+    json_data = json.dumps(data)
+    utf8_encode_data = json_data.encode('utf-8')
+    return utf8_encode_data.encode('base64').replace('\n', '')
+
+
+def get_header():
+    global rows
+    if not rows:
+        return None
+    res = (HEADER_NAME, _encode(dict(JSON_HEADER, rows=rows)))
+    rows = []
+    return res
+
+
 class DjangoMiddleware(object):
+    '''
+    This is middleware for django
+
+    After this module is installed just add "chromelogger.DjangoMiddleware"
+    to your MIDDLEWARE_CLASSES in settings.py
+    '''
     def process_response(self, request, response):
         header = get_header()
         if header is not None:
             response[header[0]] = header[1]
 
         return response
+
+
+class ChromeHandler(logging.StreamHandler):
+
+    def emit(self, record):
+        level = 'log'
+        if record.levelno >= logging.ERROR:
+            level = 'error'
+        elif record.levelno >= logging.WARNING:
+            level = 'warn'
+        elif record.levelno >= logging.INFO:
+            level = 'info'
+        backtrace = '%s:%d, %s()' % (record.pathname, record.lineno,
+                                     record.funcName)
+        _log(level, record.msg, record.args, backtrace)
+
+    def flush(self):
+        pass


### PR DESCRIPTION
Singleton is essentially the same as a module.
Logging is already part of Python, let's use that.
Patching external libraries is evil.

Also note that while reusing `logging` interface I rewrite the arguments so:

``` python
log.warn('Cannot frobnicate %s and %s', obj1, obj2)
```

Becomes (`console.log` syntax):

``` json
["Cannot frobnicate %O and %O", {…}, {…}]
```
