### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ if app.debug:
         return response
 ```
 
-This ensures that chromelogger is only active, if the apllication runs in debug-mode.
+This ensures that chromelogger is only active, if the application runs in debug-mode.
 
 ## API Documentation
 

--- a/chromelogger.py
+++ b/chromelogger.py
@@ -152,7 +152,7 @@ def table(*args):
     _log(args)
 
 
-# this is middleware for django.  ater this module is installed just add
+# this is middleware for django.  after this module is installed just add
 # "chromelogger.DjangoMiddleware" to your MIDDLEWARE_CLASSES in settings.py
 #
 # after that you can just


### PR DESCRIPTION
There are small typos in:
- README.md
- chromelogger.py

Fixes:
- Should read `application` rather than `apllication`.
- Should read `after` rather than `ater`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md